### PR TITLE
Fix the code that cause Address boundary error and Memory leak.

### DIFF
--- a/Source.c
+++ b/Source.c
@@ -429,6 +429,7 @@ void showSplash()
 	int i;
 	char logoPath[256];
 	FILE *fp;
+	logoPath[0] = '\0';
 	strcat(logoPath,getenv("HOME"));
 	strcat(logoPath,"/.conway/conwaylogo\0");
 //	char *logoPath = "/home/harwiltz/.conway/conwaylogo";
@@ -444,8 +445,8 @@ void showSplash()
 		char *stroke = line;
 		if(size == 0) for(size = 0; stroke[size] != '\0' && stroke[size] != '\n'; size++);
 		mvprintw(curcol++,cols/2 - size/2,stroke);
-		line = NULL;
 	}
+	free(line);
 	fclose(fp);
 
 	attron(COLOR_PAIR(YELLOW)|A_BOLD);


### PR DESCRIPTION
logoPath wasn't initialized before calling strcat(), storing wrong path.
Therefore, fopen() failed and NULL was assigned to fp, which caused the failure of getline() and the crash of the program.
